### PR TITLE
End to end tests should use e2e:ci command instead of just e2e

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,3 +18,6 @@ Initial Release
 
 ## v2.2
 - Added support for running E2E action
+
+## v2.3
+- Fixed issue with e2e workflow where app was unable to start.

--- a/src/scripts/kube/e2e.sh
+++ b/src/scripts/kube/e2e.sh
@@ -5,5 +5,5 @@
 if [ -f "docker-compose.e2e.yml" ]; then
     docker-compose -f docker-compose.e2e.yml up --exit-code-from app
 else
-    docker run -t "$DOCKER_IMAGE" npm run e2e
+    docker run -t "$DOCKER_IMAGE" npm run e2e:ci
 fi


### PR DESCRIPTION
## Description

End-to-end tests should use `e2e:ci` command instead of just `e2e`.
Otherwise, the app fails to start.