### PR TITLE
Release v2.5

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -7,6 +7,11 @@ inputs:
   build-args:
     required: false
     description: 'Build time arguments which can be passed when building docker image'
+  context:
+    required: false
+    description: 'Build context to use with docker. Default to checked out Git directory.'
+    default: .
+
 runs:
   using: composite
   steps:
@@ -24,7 +29,7 @@ runs:
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
-        context: .
+        context: ${{ inputs.context }}
         push: false
         tags: ${{ inputs.tag }}
         build-args: ${{ inputs.build-args }}

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -22,11 +22,11 @@ runs:
       uses: actions/cache@v2
       with:
         path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        key: ${{ inputs.tag }}-${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-buildx-
 
-    - name: Build and push
+    - name: Build
       uses: docker/build-push-action@v2
       with:
         context: ${{ inputs.context }}
@@ -35,7 +35,7 @@ runs:
         build-args: ${{ inputs.build-args }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
-        outputs: type=docker,dest=/tmp/myappimage.tar
+        outputs: type=docker,dest=/tmp/image-${{ inputs.tag }}.tar
 
     # This ugly bit is necessary if you don't want your cache to grow forever
     # till it hits GitHub's limit of 5GB.
@@ -51,6 +51,6 @@ runs:
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
-        name: myappartifact
-        path: /tmp/myappimage.tar
+        name: image-artifact-${{ inputs.tag }}
+        path: /tmp/image-${{ inputs.tag }}.tar
         retention-days: 1

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -61,7 +61,7 @@ runs:
     - name: Download artifact
       uses: actions/download-artifact@v2
       with:
-        name: myappartifact
+        name: image-artifact-${{ inputs.app_name }}
         path: /tmp
 
     - name: Extract branch name
@@ -86,7 +86,7 @@ runs:
         IMAGE_NAME=$DOCKER_REGISTRY/$DOCKER_REPOSITORY:$GITHUB_SHA
 
         docker login $DOCKER_REGISTRY --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
-        docker load --input /tmp/myappimage.tar
+        docker load --input /tmp/image-${{ inputs.app_name }}.tar
         docker tag ${{ inputs.app_name }} $IMAGE_NAME
         docker push $IMAGE_NAME
 

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -13,6 +13,9 @@ inputs:
   branch:
     required: true
     description: 'Branch from which this action was run'
+  deploy_root:
+    required: true
+    description: "Directory where kube deployment would look for kubernetes specification files"
   docker_registry:
     required: true
     description: 'Docker registry where build images would be pushed and pulled from'
@@ -101,6 +104,7 @@ runs:
         DOPPLER_TOKEN: ${{ inputs.doppler_token }}
         DOPPLER_TOKEN_SECRET_NAME: doppler-${{ inputs.app_name }}-${{ inputs.app_env }}-token-secret
         DOPPLER_MANAGED_SECRET_NAME: doppler-${{ inputs.app_name }}-${{ inputs.app_env }}-managed-secret
+        KUBE_ROOT: ${{ inputs.deploy_root }}
         KUBE_NS: ${{ inputs.app_name }}-${{ inputs.app_env }}
         KUBE_APP: ${{ inputs.app_name }}-${{ inputs.app_env }}-${{ steps.extract_branch.outputs.branch_hash }}
         KUBE_ENV: ${{ inputs.app_env }}

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Download artifact
       uses: actions/download-artifact@v2
       with:
-        name: myappartifact
+        name: image-artifact-${{ inputs.tag }}
         path: /tmp
 
     - name: Run e2e tests
@@ -21,5 +21,5 @@ runs:
       env:
         DOCKER_IMAGE: ${{ inputs.tag }}
       run: |
-        docker load --input /tmp/myappimage.tar
+        docker load --input /tmp/image-${{ inputs.tag }}.tar
         source platform/src/scripts/kube/e2e.sh

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Download artifact
       uses: actions/download-artifact@v2
       with:
-        name: myappartifact
+        name: image-artifact-${{ inputs.tag }}
         path: /tmp
 
     - name: Run linting
@@ -21,5 +21,5 @@ runs:
       env:
         DOCKER_IMAGE: ${{ inputs.tag }}
       run: |
-        docker load --input /tmp/myappimage.tar
+        docker load --input /tmp/image-${{ inputs.tag }}.tar
         docker run -t ${{ inputs.tag }} npm run lint

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Download artifact
       uses: actions/download-artifact@v2
       with:
-        name: myappartifact
+        name: image-artifact-${{ inputs.tag }}
         path: /tmp
 
     - name: Run tests
@@ -21,5 +21,5 @@ runs:
       env:
         DOCKER_IMAGE: ${{ inputs.tag }}
       run: |
-        docker load --input /tmp/myappimage.tar
+        docker load --input /tmp/image-${{ inputs.tag }}.tar
         source platform/src/scripts/kube/test.sh

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
         description: "Branch from which platform will be checked out to use actions"
-        default: "v2.4"
+        default: "v2.5"
     secrets:
       do_access_token:
         required: true

--- a/.github/workflows/kube.yml
+++ b/.github/workflows/kube.yml
@@ -216,7 +216,7 @@ jobs:
 
       - uses: marocchino/sticky-pull-request-comment@v2
         # only run this step if enabled and pull request number was provided
-        if: inputs.deploy_annotate_pr == 'true' && inputs.pull_request_number
+        if: inputs.deploy_annotate_pr == true && inputs.pull_request_number
         with:
           header: ${{ inputs.app_name }}
           hide_and_recreate: true

--- a/.github/workflows/kube.yml
+++ b/.github/workflows/kube.yml
@@ -39,7 +39,7 @@ on:
         required: false
         type: string
         description: "Branch from which platform will be checked out to use actions"
-        default: "v2.4"
+        default: "v2.5"
     secrets:
       docker_registry:
         required: true

--- a/.github/workflows/kube.yml
+++ b/.github/workflows/kube.yml
@@ -218,6 +218,7 @@ jobs:
         # only run this step if enabled and pull request number was provided
         if: inputs.deploy_annotate_pr == 'true' && inputs.pull_request_number
         with:
+          header: ${{ inputs.app_name }}
           hide_and_recreate: true
           hide_classify: "OUTDATED"
           number: ${{ inputs.pull_request_number }}

--- a/.github/workflows/kube.yml
+++ b/.github/workflows/kube.yml
@@ -223,7 +223,7 @@ jobs:
           hide_classify: "OUTDATED"
           number: ${{ inputs.pull_request_number }}
           message: |
-            Deployment is available at - ${{ steps.deploy.outputs.url }}
+            Deployment (${{ inputs.app_name }}) is available at - ${{ steps.deploy.outputs.url }}
 
   clean:
     runs-on: ubuntu-latest

--- a/.github/workflows/kube.yml
+++ b/.github/workflows/kube.yml
@@ -62,6 +62,10 @@ on:
         required: false
       sonar_token:
         required: false
+    outputs:
+      deploy_url:
+        description: "Deployment URL"
+        value: ${{ jobs.deploy.outputs.url }}
 
 jobs:
   analyze:
@@ -171,6 +175,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: inputs.steps == '' || contains(join(inputs.steps), 'deploy')
+    outputs:
+      url: ${{ steps.deploy.outputs.url }}
     steps:
       - name: Checkout (source)
         uses: actions/checkout@v2

--- a/.github/workflows/kube.yml
+++ b/.github/workflows/kube.yml
@@ -32,6 +32,11 @@ on:
         type: string
         description: "Build context to use with docker. Default to checked out Git directory."
         default: .
+      deploy_root:
+        required: false
+        type: string
+        description: "Directory where kube deployment would look for kubernetes specification files"
+        default: "lib/kube"
       pull_request_number:
         required: false
         type: number
@@ -196,6 +201,7 @@ jobs:
           app_env: ${{ inputs.app_env }}
           app_hostname: ${{ inputs.app_hostname }}
           branch: ${{ inputs.branch }}
+          deploy_root: ${{ inputs.deploy_root }}
           docker_registry: ${{ secrets.docker_registry }}
           docker_username: ${{ secrets.docker_username }}
           docker_password: ${{ secrets.docker_password }}

--- a/.github/workflows/kube.yml
+++ b/.github/workflows/kube.yml
@@ -233,5 +233,5 @@ jobs:
     steps:
       - uses: geekyeggo/delete-artifact@v1
         with:
-          name: myappartifact
+          name: image-artifact-${{ inputs.app_name }}
           failOnError: false

--- a/.github/workflows/kube.yml
+++ b/.github/workflows/kube.yml
@@ -37,6 +37,11 @@ on:
         type: string
         description: "Directory where kube deployment would look for kubernetes specification files"
         default: "lib/kube"
+      deploy_annotate_pr:
+        required: false
+        type: boolean
+        description: "Enable pull request annotation with deployment URL"
+        default: true
       pull_request_number:
         required: false
         type: number
@@ -210,8 +215,8 @@ jobs:
           doppler_token: ${{ secrets.doppler_token }}
 
       - uses: marocchino/sticky-pull-request-comment@v2
-        # only run this step if a pull request number was provided
-        if: inputs.pull_request_number
+        # only run this step if enabled and pull request number was provided
+        if: inputs.deploy_annotate_pr == 'true' && inputs.pull_request_number
         with:
           hide_and_recreate: true
           hide_classify: "OUTDATED"

--- a/.github/workflows/kube.yml
+++ b/.github/workflows/kube.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: string
         description: "Build arguments provided to the docker daemon when building the image"
+      build_context:
+        required: false
+        type: string
+        description: "Build context to use with docker. Default to checked out Git directory."
+        default: .
       pull_request_number:
         required: false
         type: number
@@ -100,6 +105,7 @@ jobs:
         with:
           tag: ${{ inputs.app_name }}
           build-args: ${{ inputs.build_args }}
+          context: ${{ inputs.build_context }}
 
   lint:
     runs-on: ubuntu-latest

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,3 +25,8 @@ Initial Release
 - [chore] Analyze was moved to its own action
 - [fix] Fixed issue where analyze step does not fails if SonarQube code quality check is failing
 - [fix] Fixed issue where analysis was never being run for `main` branch
+
+## v2.5
+- [feat] Added support for `build_context` input which can be used to build docker images from different directory than root
+- [feat] Added support for `deploy_root` input which can be used for specifying kubernetes specification files from different directories
+- [feat] Added support for `deploy_url` output which has the url for deployment made by the workflow

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,3 +30,5 @@ Initial Release
 - [feat] Added support for `build_context` input which can be used to build docker images from different directory than root
 - [feat] Added support for `deploy_root` input which can be used for specifying kubernetes specification files from different directories
 - [feat] Added support for `deploy_url` output which has the url for deployment made by the workflow
+- [feat] Added support for `deploy_annotate_pr` input which can be used to disable pull request annotation
+- [feat] Added support for github annotation for multiple apps using `header`

--- a/src/scripts/kube/deploy.sh
+++ b/src/scripts/kube/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # requires - kubectl
-# requires - KUBE_NS, KUBE_APP, KUBE_ENV, KUBE_DEPLOYMENT_IMAGE, KUBE_INGRESS_HOSTNAME
+# requires - KUBE_ROOT, KUBE_NS, KUBE_APP, KUBE_ENV, KUBE_DEPLOYMENT_IMAGE, KUBE_INGRESS_HOSTNAME
 # requires - DOCKER_REGISTRY, DOCKER_USERNAME, DOCKER_PASSWORD
 # optional - DOPPLER_TOKEN, DOPPLER_TOKEN_SECRET_NAME, DOPPLER_MANAGED_SECRET_NAME
 
@@ -31,9 +31,9 @@ kubectl create secret docker-registry regcred --docker-server="$DOCKER_REGISTRY"
 
 # apply kube config (core / shared / env)
 
-kube_core_dir="lib/kube/core"
-kube_shared_dir="lib/kube/shared"
-kube_env_dir="lib/kube/$KUBE_ENV"
+kube_core_dir="$KUBE_ROOT/core"
+kube_shared_dir="$KUBE_ROOT/shared"
+kube_env_dir="$KUBE_ROOT/$KUBE_ENV"
 
 if [ -d "$kube_core_dir" ]; then
     for file in "$kube_core_dir"/*; do


### PR DESCRIPTION
## Description
- Added support for `build_context` input which can be used to build docker images from different directory than root
- Added support for `deploy_root` input which can be used for specifying kubernetes specification files from different directories
- Added support for `deploy_url` output which has the url for deployment made by the workflow
- Added support for `deploy_annotate_pr` input which can be used to disable pull request annotation
- Added support for github annotation for multiple apps using `header`